### PR TITLE
[10.0][sale_commission_formula] add method to define formula parameters to be used

### DIFF
--- a/sale_commission_formula/models/account_invoice.py
+++ b/sale_commission_formula/models/account_invoice.py
@@ -10,6 +10,11 @@ from odoo.tools.safe_eval import safe_eval
 class AccountInvoiceLineAgent(models.Model):
     _inherit = 'account.invoice.line.agent'
 
+    @api.model
+    def _get_formula_input_dict(self):
+        return {'line': self.sale_line,
+                'self': self}
+
     @api.depends('commission.commission_type', 'invoice_line.price_subtotal',
                  'commission.amount_base_type')
     def _compute_amount(self):
@@ -19,7 +24,7 @@ class AccountInvoiceLineAgent(models.Model):
                     line_obj.commission):
                 line_obj.amount = 0.0
                 formula = line_obj.commission.formula
-                results = {'line': line_obj.invoice_line}
+                results = line_obj._get_formula_input_dict()
                 safe_eval(formula, results, mode="exec", nocopy=True)
                 line_obj.amount += float(results['result'])
             else:

--- a/sale_commission_formula/models/sale_order.py
+++ b/sale_commission_formula/models/sale_order.py
@@ -10,6 +10,11 @@ from odoo.tools.safe_eval import safe_eval
 class SaleOrderLineAgent(models.Model):
     _inherit = 'sale.order.line.agent'
 
+    @api.model
+    def _get_formula_input_dict(self):
+        return {'line': self.sale_line,
+                'self': self}
+
     @api.depends('commission.commission_type', 'sale_line.price_subtotal',
                  'commission.amount_base_type')
     def _compute_amount(self):
@@ -19,7 +24,7 @@ class SaleOrderLineAgent(models.Model):
                     line_agent.commission):
                 line_agent.amount = 0.0
                 formula = line_agent.commission.formula
-                results = {'line': line_agent.sale_line}
+                results = line_agent._get_formula_input_dict()
                 safe_eval(formula, results, mode="exec", nocopy=True)
                 line_agent.amount += float(results['result'])
             else:


### PR DESCRIPTION
We have used this module and in our case we needed more flexibility in order to access to different parameters when defining the formula. 
For this reason, we have improved the SaleOrderLineAgent class with a new method that allows you to extend the dictionary of parameters.
